### PR TITLE
FIX: Progress Icon on windows

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -106,8 +106,14 @@ export default function Command() {
 						accessories={[
 							{
 								icon: {
-									source: getProgressIcon(item.current_totp_time_remaining / 30),
-									tintColor: getProgressColor(item.current_totp_time_remaining),
+									source: getProgressIcon(
+										item.current_totp_time_remaining / 30,
+										getProgressColor(item.current_totp_time_remaining),
+										{
+											background: getProgressColor(item.current_totp_time_remaining),
+											backgroundOpacity: 0.35,
+										}
+									),
 								},
 							},
 						]}


### PR DESCRIPTION
The current implementation does not display the progress icon correctly on windows.
This update uses the `getProgressIcon` utility as described in the Raycast documentation, ensuring the icon now renders properly on both Windows and macOS.

Raycast Docs: https://developers.raycast.com/utilities/icons/getprogressicon